### PR TITLE
Display mainnet warning on page reload

### DIFF
--- a/src/components/MainnetWarningModal/index.tsx
+++ b/src/components/MainnetWarningModal/index.tsx
@@ -1,9 +1,6 @@
 import React from 'react'
 import Modal from '../Modal'
 import { ButtonGradient } from '../Button'
-import { useDispatch, useSelector } from 'react-redux'
-import { AppDispatch, AppState } from '../../state'
-import { toggleMainnetWarning } from '../../state/user/actions'
 import { ExternalLink, TYPE } from '../../theme'
 import styled from 'styled-components'
 import Row from '../Row'
@@ -26,12 +23,11 @@ const StyledWarningIcon = styled(AlertTriangle)`
 `
 
 export const MainnetWarningModal = () => {
-  // displays mainnetwarning modal based on MainnetWarningModal state
-  const showMainnetWarningModal = useSelector((state: AppState) => state.user.MainnetWarningVisible)
-  const dispatch = useDispatch<AppDispatch>()
+  // displays mainnetwarning modal on page load
+  const [showMainnetWarningModal, setShowMainnetWarningModal] = React.useState(true)
 
   const hideMainnetWarningModal = () => {
-    dispatch(toggleMainnetWarning())
+    setShowMainnetWarningModal(false)
   }
 
   return showMainnetWarningModal ? (

--- a/src/state/user/actions.ts
+++ b/src/state/user/actions.ts
@@ -27,4 +27,3 @@ export const removeSerializedPair = createAction<{ chainId: number; tokenAAddres
   'user/removeSerializedPair'
 )
 export const toggleURLWarning = createAction<void>('app/toggleURLWarning')
-export const toggleMainnetWarning = createAction<void>('user/toggleMainnetWarning')

--- a/src/state/user/reducer.ts
+++ b/src/state/user/reducer.ts
@@ -13,8 +13,7 @@ import {
   updateUserExpertMode,
   updateUserSlippageTolerance,
   updateUserDeadline,
-  toggleURLWarning,
-  toggleMainnetWarning
+  toggleURLWarning
 } from './actions'
 
 const currentTimestamp = () => new Date().getTime()
@@ -49,7 +48,6 @@ export interface UserState {
 
   timestamp: number
   URLWarningVisible: boolean
-  MainnetWarningVisible: boolean
 }
 
 function pairKey(token0Address: string, token1Address: string) {
@@ -65,8 +63,7 @@ export const initialState: UserState = {
   tokens: {},
   pairs: {},
   timestamp: currentTimestamp(),
-  URLWarningVisible: true,
-  MainnetWarningVisible: true
+  URLWarningVisible: true
 }
 
 export default createReducer(initialState, builder =>
@@ -137,11 +134,5 @@ export default createReducer(initialState, builder =>
     })
     .addCase(toggleURLWarning, state => {
       state.URLWarningVisible = !state.URLWarningVisible
-    })
-    .addCase(toggleMainnetWarning, state => {
-      if (typeof state.MainnetWarningVisible !== 'boolean') {
-        state.MainnetWarningVisible = false
-      }
-      state.MainnetWarningVisible = !state.MainnetWarningVisible
     })
 )


### PR DESCRIPTION
This PR changes the mainnet warning behavior. The mainnet warning now appears whenever a user reloads a page