### PR TITLE
Feat/integrate starknet #129

### DIFF
--- a/src/components/Web3Status/index.tsx
+++ b/src/components/Web3Status/index.tsx
@@ -1,7 +1,7 @@
 import { AbstractConnector } from '@web3-starknet-react/abstract-connector'
 import { UnsupportedChainIdError, useStarknetReact } from '@web3-starknet-react/core'
 import { darken, lighten } from 'polished'
-import React, { useMemo } from 'react'
+import React, { useMemo, useEffect, useState } from 'react'
 // import { Activity } from 'react-feather'
 import { useTranslation } from 'react-i18next'
 import styled, { css } from 'styled-components'
@@ -26,6 +26,8 @@ import { RowBetween } from '../Row'
 import WalletModal from '../WalletModal'
 import WrongNetwork from '../../assets/jedi/WrongNetwork.svg'
 import { useActiveStarknetReact } from '../../hooks'
+import { hexToDecimalString } from 'starknet/dist/utils/number'
+
 
 const IconWrapper = styled.div<{ size?: number }>`
   ${({ theme }) => theme.flexColumnNoWrap};
@@ -193,12 +195,14 @@ function StatusIcon({ connector }: { connector: AbstractConnector }) {
   return null
 }
 
-function Web3StatusInner() {
+function Web3StatusInner({
+  starkID
+  }: {
+  starkID?: string
+  }) {
   const { t } = useTranslation()
   const { connectedAddress, connector, error } = useActiveStarknetReact()
-
-  // const { ENSName } = useENSName(connectedAddress ?? undefined)
-
+  
   const allTransactions = useAllTransactions()
 
   const sortedRecentTransactions = useMemo(() => {
@@ -223,7 +227,8 @@ function Web3StatusInner() {
             <Text>{pending?.length} Pending</Text> <Loader stroke="white" />
           </RowBetween>
         ) : (
-          <Text>{shortenAddress(connectedAddress)}</Text>
+          <Text>{starkID ? starkID : shortenAddress(connectedAddress)}</Text>
+          
         )}
       </Web3StatusConnected>
     )
@@ -246,8 +251,20 @@ function Web3StatusInner() {
 export default function Web3Status() {
   const { active, connectedAddress } = useStarknetReact()
   const contextNetwork = useStarknetReact(NetworkContextName)
+  
+  const [domain, setDomain] = useState<any>("");
 
-  // const { ENSName } = useENSName(connectedAddress ?? undefined)
+  useEffect(() => {
+    fetch("https://app.starknet.id/api/indexer/addr_to_domain?addr=" + hexToDecimalString(connectedAddress ?? ""))
+      .then(response => response.json())
+      .then(data => {
+        console.log(data.domain)
+        setDomain(data.domain);
+      })
+      .catch(error => {
+        console.error(error);
+      });
+  }, [connectedAddress]);
 
   const allTransactions = useAllTransactions()
 
@@ -270,8 +287,8 @@ export default function Web3Status() {
 
   return (
     <>
-      <Web3StatusInner />
-      <WalletModal pendingTransactions={pending} confirmedTransactions={confirmed} />
+      <Web3StatusInner starkID={domain}/>
+      <WalletModal pendingTransactions={pending} confirmedTransactions={confirmed} ENSName={domain}/>
     </>
   )
 }

--- a/src/components/Web3Status/index.tsx
+++ b/src/components/Web3Status/index.tsx
@@ -28,7 +28,6 @@ import WrongNetwork from '../../assets/jedi/WrongNetwork.svg'
 import { useActiveStarknetReact } from '../../hooks'
 import { hexToDecimalString } from 'starknet/dist/utils/number'
 
-
 const IconWrapper = styled.div<{ size?: number }>`
   ${({ theme }) => theme.flexColumnNoWrap};
   align-items: center;
@@ -195,14 +194,10 @@ function StatusIcon({ connector }: { connector: AbstractConnector }) {
   return null
 }
 
-function Web3StatusInner({
-  starkID
-  }: {
-  starkID?: string
-  }) {
+function Web3StatusInner({ starkID }: { starkID?: string }) {
   const { t } = useTranslation()
   const { connectedAddress, connector, error } = useActiveStarknetReact()
-  
+
   const allTransactions = useAllTransactions()
 
   const sortedRecentTransactions = useMemo(() => {
@@ -228,7 +223,6 @@ function Web3StatusInner({
           </RowBetween>
         ) : (
           <Text>{starkID ? starkID : shortenAddress(connectedAddress)}</Text>
-          
         )}
       </Web3StatusConnected>
     )
@@ -251,20 +245,20 @@ function Web3StatusInner({
 export default function Web3Status() {
   const { active, connectedAddress } = useStarknetReact()
   const contextNetwork = useStarknetReact(NetworkContextName)
-  
-  const [domain, setDomain] = useState<any>("");
+
+  const [domain, setDomain] = useState<any>('')
 
   useEffect(() => {
-    fetch("https://app.starknet.id/api/indexer/addr_to_domain?addr=" + hexToDecimalString(connectedAddress ?? ""))
+    fetch('https://app.starknet.id/api/indexer/addr_to_domain?addr=' + hexToDecimalString(connectedAddress ?? ''))
       .then(response => response.json())
       .then(data => {
         console.log(data.domain)
-        setDomain(data.domain);
+        setDomain(data.domain)
       })
       .catch(error => {
-        console.error(error);
-      });
-  }, [connectedAddress]);
+        console.error(error)
+      })
+  }, [connectedAddress])
 
   const allTransactions = useAllTransactions()
 
@@ -287,8 +281,8 @@ export default function Web3Status() {
 
   return (
     <>
-      <Web3StatusInner starkID={domain}/>
-      <WalletModal pendingTransactions={pending} confirmedTransactions={confirmed} ENSName={domain}/>
+      <Web3StatusInner starkID={domain} />
+      <WalletModal pendingTransactions={pending} confirmedTransactions={confirmed} ENSName={domain} />
     </>
   )
 }

--- a/src/components/Web3Status/index.tsx
+++ b/src/components/Web3Status/index.tsx
@@ -246,13 +246,14 @@ export default function Web3Status() {
   const { active, connectedAddress } = useStarknetReact()
   const contextNetwork = useStarknetReact(NetworkContextName)
 
-  const [domain, setDomain] = useState<any>('')
+  type DomainToAddrData = { domain: string; domain_expiry: number }
+
+  const [domain, setDomain] = useState<string>('')
 
   useEffect(() => {
     fetch('https://app.starknet.id/api/indexer/addr_to_domain?addr=' + hexToDecimalString(connectedAddress ?? ''))
       .then(response => response.json())
-      .then(data => {
-        console.log(data.domain)
+      .then((data: DomainToAddrData) => {
         setDomain(data.domain)
       })
       .catch(error => {


### PR DESCRIPTION
Add feature from #129.

I integrated starknet id top-right in the navbar
<img width="395" alt="image" src="https://user-images.githubusercontent.com/101047205/221838821-642b8696-6bbe-4425-8d27-7dfb1afcaa75.png">
and in the wallet modal.

The only file I changed is src/components/Web3Status/index.tsx

I initially wanted to use the [provider function](https://www.starknetjs.com/docs/API/Provider/#getstarkname) from starknet.js but the required version was 4.22.0 while the repo's is 4.4.2.
To avoid having to upgrade starknet.js package I used this [api call ](https://docs.starknet.id/for-devs/api-domain-integration#address-to-domain).



