### PR TITLE
fix settings panels mobile layout

### DIFF
--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -94,6 +94,10 @@ const MenuGradientWrapper = styled.span`
   top: 2.75rem;
   right: 0.5rem;
   z-index: 100;
+
+  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
+    right: -2rem;
+  `};
 `
 
 const MenuFlyout = styled.span`


### PR DESCRIPTION
Edit right margin for phones screens to correctly display the panel.
**right now:**
![settings-issue](https://github.com/jediswaplabs/jediswap-interface/assets/44796732/82263889-aae1-483f-b3fe-9e4fe74ee509)

**after fix:**
![settings-fix](https://github.com/jediswaplabs/jediswap-interface/assets/44796732/c6718e0b-d5ab-4443-9786-900de1b5595a)
