### PR TITLE
Fixed condition for the input right margin

### DIFF
--- a/src/components/CurrencyInputPanel/index.tsx
+++ b/src/components/CurrencyInputPanel/index.tsx
@@ -197,6 +197,8 @@ CurrencyInputPanelProps) {
     setModalOpen(false)
   }, [setModalOpen])
 
+  const displayMaxButton = connectedAddress && currency && showMaxButton && label !== 'To';
+
   return (
     <InputPanel id={id}>
       <Container hideInput={hideInput}>
@@ -280,10 +282,10 @@ CurrencyInputPanelProps) {
                 onUserInput={val => {
                   onUserInput(val)
                 }}
-                style={showMaxButton ? { paddingRight: '60px' } : { paddingRight: '12px' }}
+                style={displayMaxButton ? { paddingRight: '60px' } : { paddingRight: '12px' }}
                 disabled={disableInput}
               />
-              {connectedAddress && currency && showMaxButton && label !== 'To' && (
+              {displayMaxButton && (
                 <StyledBalanceMax onClick={onMax}>MAX</StyledBalanceMax>
               )}
             </>


### PR DESCRIPTION
We need a 60 px right margin only if we display the max_button. So, the conditions should be the same in both cases. Right now, excessive right margin leads to a display problem on small screens.

 
![photo_2023-05-24_21-09-48](https://github.com/jediswaplabs/jediswap-interface/assets/44796732/57b9f7f2-fd52-44b8-b628-aac402b26d3d)
